### PR TITLE
Fix: optional BigNumber array on emergencyreport, extractOutcomes utility

### DIFF
--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@polymarket/uma-binary-adapter-sdk",
     "description": "SDK for the UMA Binary Adapter",
-    "version": "1.1.6",
+    "version": "1.1.7",
     "contributors": [
         {
             "name": "Jonathan Amenechi",

--- a/packages/sdk/src/adapter.ts
+++ b/packages/sdk/src/adapter.ts
@@ -299,7 +299,7 @@ export class UmaBinaryAdapterClient {
      */
     public async emergencyReportPayouts(
         questionID: string,
-        payouts: number[],
+        payouts: number[] | BigNumber[],
         overrides?: ethers.Overrides,
     ): Promise<TransactionReceipt> {
         console.log(`Emergency resolving question...`);

--- a/packages/sdk/src/utils.ts
+++ b/packages/sdk/src/utils.ts
@@ -11,6 +11,17 @@ export const buildResolutionData = (outcomes: string[]): string => {
     return `p1: 0, p2: 1, p3: 0.5. Where p2 corresponds to ${outcomes[0]}, p1 to a ${outcomes[1]}, p3 to unknown`;
 }
 
+export const OUTCOME_REGEX = /Where p2 corresponds to (\w+), p1 to a (\w+)/;
+
+export const extractOutcomes = (ancillaryDataString: string): string[] | null => {
+    const matched = ancillaryDataString.match(OUTCOME_REGEX);
+    if (matched && matched.length == 3) {
+        const outcomes: string[] = [matched[1], matched[2]];
+        return outcomes;
+    }
+    return null;
+}
+
 
 /**
  * Creates the ancillary data used to resolve questions


### PR DESCRIPTION
- Add BigNumber payout array on emergencyReportPayouts. Necessary for fractional payouts(these must be converted to big number)
- Add utility to extract the outcomes from an ancillary data string